### PR TITLE
Remove upper Python version constraint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+[0.1.3] - 2022-06-11
+--------------------
+
+Fixed
+^^^^^
+
+* Allow install with Python 3.10 (and later)
+
+
 [0.1.2] - 2022-02-13
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ repository = "https://github.com/jgosmann/bite-parser/"
 version = "0.1.2"
 
 [tool.poetry.dependencies]
-python = "^3.7,<=3.10"
+python = "^3.7"
 
 [tool.poetry.dev-dependencies]
 black = "^21.9b0"


### PR DESCRIPTION
It was copied errorneously from dmarc-metrics-exporter.